### PR TITLE
Adding factory_bot dependency

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-performance
   - rubocop-rspec
   - rubocop-rails
+  - rubocop-factory_bot
 
 inherit_from:
   - config/layout.yml

--- a/streemline-rubocop.gemspec
+++ b/streemline-rubocop.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop-performance'
   spec.add_runtime_dependency 'rubocop-rails'
   spec.add_runtime_dependency 'rubocop-rspec'
+  spec.add_runtime_dependency 'rubocop-factory_bot'
 end


### PR DESCRIPTION
Since it was [removed](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#300-2024-06-11) from `rubocop-rspec` we need to add it explicitly.